### PR TITLE
Feature: Turning datepicker into a controlled component

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
   "dependencies": {
     "classnames": "^2.2.5",
     "date-fns": "^1.29.0",
-    "dayzed": "^2.2.0"
+    "dayzed": "^2.2.0",
+    "react-fast-compare": "^2.0.1"
   },
   "devDependencies": {
     "@storybook/react": "^3.4.0",

--- a/src/components/calendar/calendar.css
+++ b/src/components/calendar/calendar.css
@@ -2,6 +2,7 @@
   text-align: center;
   position: absolute !important;
   margin-top: 0.25rem !important;
+  z-index: 2000;
 }
 
 .clndr-calendars-wrapper {

--- a/src/components/datepicker.js
+++ b/src/components/datepicker.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import isEqual from 'react-fast-compare';
 import { formatSelectedDate, moveElementsByN, omit, pick } from '../utils';
 import localeEn from '../locales/en-US';
 import BasicDatePicker from '../pickers/basic';
@@ -52,6 +53,14 @@ class SemanticDatepicker extends React.Component {
     selected: null,
     type: 'basic',
   };
+
+  componentDidUpdate(prevProps) {
+    const { selected } = this.props;
+
+    if (!isEqual(selected, prevProps.selected)) {
+      this.onDateSelected(selected);
+    }
+  }
 
   get isRangeInput() {
     return this.props.type === 'range';

--- a/src/components/datepicker.js
+++ b/src/components/datepicker.js
@@ -26,6 +26,7 @@ class SemanticDatepicker extends React.Component {
   static propTypes = {
     clearable: PropTypes.bool,
     date: PropTypes.instanceOf(Date),
+    firstDayOfWeek: PropTypes.number,
     format: PropTypes.string,
     keepOpenOnClear: PropTypes.bool,
     keepOpenOnSelect: PropTypes.bool,
@@ -44,6 +45,7 @@ class SemanticDatepicker extends React.Component {
     keepOpenOnClear: false,
     keepOpenOnSelect: false,
     date: undefined,
+    firstDayOfWeek: 0,
     format: 'YYYY-MM-DD',
     locale: localeEn,
     placeholder: null,
@@ -151,7 +153,7 @@ class SemanticDatepicker extends React.Component {
   handleRangeInput = newDates => {
     const { format, keepOpenOnSelect, onDateChange } = this.props;
 
-    if (!newDates.length) {
+    if (!newDates || !newDates.length) {
       this.resetState();
 
       return;


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- Is it a bug fix, feature, docs update, ... -->

**What kind of change does this PR introduce?**
You can now use `onDateChange` and `selected` props to control the datepicker, just like you would use `onChange` and `value` in an input element.

Also, it adds a default prop to `firstDayOfWeek` and a `z-index` to the calendar component.
<!-- You can also link to an open issue here -->

**What is the current behavior?**
The `state` of the datepicker is not updated when a new `selected` prop is provided.
<!-- if this is a feature change -->

**What is the new behavior?**
When a new `selected` prop is provided, the datepicker recalculates its state.
<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->

<!-- Thank you for contributing! -->
