### PR TITLE
fix(package.json): Replacing `postinstall` for `prepare` script

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "lint": "kcd-scripts lint",
     "precommit": "kcd-scripts precommit",
     "predeploy": "npm run storybook:build",
-    "postinstall": "cd date-fns-v2/ && npm install",
+    "prepare": "cd date-fns-v2/ && npm install",
     "semantic-release": "semantic-release",
     "storybook": "start-storybook -p 9001 -c stories",
     "storybook:build": "build-storybook -c stories",


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- Is it a bug fix, feature, docs update, ... -->

**What kind of change does this PR introduce?**
Bug fix.
<!-- You can also link to an open issue here -->

**What is the current behavior?**
The change implemented on #13 added the `postinstall` script. However, it broke the installation of the library because there isn't a `date-fns-v2` folder in the files published to npm.
<!-- if this is a feature change -->

**What is the new behavior?**
The `prepare` script does what the `postinstall` script did, but it only runs in development environment.
<!-- Have you done all of these things?  -->


<!-- feel free to add additional comments -->

<!-- Thank you for contributing! -->
