### PR TITLE
fix(datepicker): Firing the onBlur event passed as prop

### DIFF
--- a/src/components/datepicker.js
+++ b/src/components/datepicker.js
@@ -58,6 +58,7 @@ class SemanticDatepicker extends React.Component {
     keepOpenOnClear: PropTypes.bool,
     keepOpenOnSelect: PropTypes.bool,
     locale: PropTypes.object,
+    onBlur: PropTypes.func,
     onDateChange: PropTypes.func.isRequired,
     placeholder: PropTypes.string,
     selected: PropTypes.oneOfType([
@@ -78,6 +79,7 @@ class SemanticDatepicker extends React.Component {
     keepOpenOnClear: false,
     keepOpenOnSelect: false,
     locale: localeEn,
+    onBlur: () => {},
     placeholder: null,
     pointing: 'left',
     selected: null,
@@ -235,9 +237,11 @@ class SemanticDatepicker extends React.Component {
     });
   };
 
-  handleBlur = () => {
-    const { format } = this.props;
+  handleBlur = event => {
+    const { format, onBlur } = this.props;
     const { typedValue } = this.state;
+
+    onBlur(event);
 
     if (!typedValue) {
       return;


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- Is it a bug fix, feature, docs update, ... -->

**What kind of change does this PR introduce?**
Bug fix.
<!-- You can also link to an open issue here -->

**What is the current behavior?**
When this component is used with libraries such as `react-final-form`, the validation doesn't work properly because the form library validates each input on blur, but the datepicker doesn't fire the event.
<!-- if this is a feature change -->

**What is the new behavior?**
The prop `onBlur`, which defaults to an "empty function" is now fired, allowing such validations to work properly.
<!-- Have you done all of these things?  -->
