### PR TITLE
Update TypeScript definitions to remove duplicate definition

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -31,7 +31,6 @@ export interface SemanticDatepickerProps {
   name?: string;
   onDateChange: (newDate: Date | Date[] | null) => void;
   placeholder?: string;
-  placeholder?: string;
   selected?: Date | Date[];
   showOutsideDays?: boolean;
   size?: SemanticSIZES;


### PR DESCRIPTION
As per title - this seems to prevent TS compilation.