### PR TITLE
Add `readOnly` as a supported Form.Input prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ More examples [here](https://react-semantic-ui-datepickers.now.sh).
 - placeholder
 - size
 - transparent
+- readOnly
 
 ### Dayzed Props
 

--- a/src/components/datepicker.js
+++ b/src/components/datepicker.js
@@ -48,6 +48,7 @@ const semanticInputProps = [
   'required',
   'size',
   'transparent',
+  'readOnly',
 ];
 
 class SemanticDatepicker extends React.Component {
@@ -70,6 +71,7 @@ class SemanticDatepicker extends React.Component {
     type: PropTypes.oneOf(['basic', 'range']),
     pointing: PropTypes.oneOf(['left', 'right', 'top left', 'top right']),
     filterDate: PropTypes.func,
+    readOnly: PropTypes.bool,
   };
 
   static defaultProps = {

--- a/stories/index.js
+++ b/stories/index.js
@@ -30,6 +30,11 @@ storiesOf('Examples', module)
       <SemanticDatepicker onDateChange={console.log} />
     </Content>
   ))
+  .add('Basic Readonly', () => (
+    <Content>
+      <SemanticDatepicker onDateChange={console.log} readOnly={true} />
+    </Content>
+  ))
   .add('Basic with allowOnlyNumbers', () => (
     <Content>
       <SemanticDatepicker allowOnlyNumbers onDateChange={console.log} />


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- Is it a bug fix, feature, docs update, ... -->
This PR is a feature. It adds `readOnly` as one of the supported `Form.Input` props.

**What kind of change does this PR introduce?**
 It adds `readOnly` as one of the supported `Form.Input` props.

<!-- You can also link to an open issue here -->

**What is the current behavior?**
`readOnly` is not a supported prop of `Form.Input`. 

<!-- if this is a feature change -->

**What is the new behavior?**
`readOnly` is now a supported prop of `Form.Input`.  

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation (Updated README.md to reflect new prop support)
- [x] Tests (Tested that the prop works as intended in the storybook)
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->


<!-- Thank you for contributing! -->
