### PR TITLE
fix(datepicker): showCalendar no longer triggers if readOnly is true

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@storybook/react": "^3.4.0",
     "babel-core": "^6.26.0",
     "babel-runtime": "^6.26.0",
-    "kcd-scripts": "^1.4.0",
+    "kcd-scripts": "^1.8.0",
     "prop-types": "^15.6.1",
     "react": ">=16.2.1",
     "react-dom": ">=16.2.1",

--- a/src/components/datepicker.js
+++ b/src/components/datepicker.js
@@ -91,6 +91,7 @@ class SemanticDatepicker extends React.Component {
     pointing: 'left',
     selected: null,
     type: 'basic',
+    readOnly: false,
   };
 
   componentDidUpdate(prevProps) {
@@ -340,7 +341,7 @@ class SemanticDatepicker extends React.Component {
       selectedDateFormatted,
       typedValue,
     } = this.state;
-    const { clearable, locale, pointing, filterDate } = this.props;
+    const { clearable, locale, pointing, filterDate, readOnly } = this.props;
     return (
       <div
         className="field"
@@ -355,7 +356,7 @@ class SemanticDatepicker extends React.Component {
           onBlur={this.handleBlur}
           onChange={this.handleChange}
           onClear={this.resetState}
-          onClick={this.showCalendar}
+          onClick={readOnly ? null : this.showCalendar}
           onKeyDown={this.handleKeyDown}
           value={typedValue || selectedDateFormatted}
         />


### PR DESCRIPTION
This PR is a bug fix for issue https://github.com/arthurdenner/react-semantic-ui-datepickers/issues/41. It ensures the date picker is not shown if the field is marked as `readOnly`.

**What kind of change does this PR introduce?**

It ensures the date picker is not shown if the field is marked as `readOnly`.

**What is the current behavior?**

Currently, when clicking on an input marked as `readOnly`, the date picker will still be displayed.

**What is the new behavior?**

Now, when clicking on an input marked as `readOnly`, the date picker will no longer be displayed.

**Checklist**:

- [ ] Documentation (N/A)
- [x] Tests
- [x] Ready to be merged