### PR TITLE
fix(types): add Catalan locale key to options of locale prop

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,3 +44,7 @@ Also, make sure to run the tests before you commit your changes:
 `npm run test` or `yarn test`.
 
 Thank you for taking the time to contribute! 👍
+
+## Want to add a locale?
+
+Check the instructions on [this issue](https://github.com/arthurdenner/react-semantic-ui-datepickers/issues/2).

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -15,6 +15,7 @@ export type Locale = {
 };
 
 export type LocaleOptions =
+  | 'ca-ES'
   | 'de-DE'
   | 'en-US'
   | 'es-ES'


### PR DESCRIPTION

<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- Is it a bug fix, feature, docs update, ... -->

**What kind of change does this PR introduce?**
Bugfix. Missing implementation from #80.
<!-- You can also link to an open issue here -->

**What is the current behavior?**
We didn't add `ca-ES` as one of the possible values to the `locale` prop.
<!-- if this is a feature change -->

**What is the new behavior?**
Now we have it.

PS: The instructions about how to add a locale were updated on the related issue.
<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [ ] Tests
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->

<!-- Thank you for contributing! -->
