### PR TITLE
Add support for date picker only mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ More examples [here](https://react-semantic-ui-datepickers.now.sh).
 - size
 - transparent
 - readOnly
+- datePickerOnly
 
 ### Dayzed Props
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ More examples [here](https://react-semantic-ui-datepickers.now.sh).
 | onChange             | function | no       | () => {}     | Callback fired when the value changes                                                                           |
 | pointing             | string   | no       | 'left'       | Location to render the component around input. Available options: 'left', 'right', 'top left', 'top right'      |
 | type                 | string   | no       | basic        | Type of input to render. Available options: 'basic' and 'range'                                                 |
+| datePickerOnly       | boolean  | no       | false        | Allows the date to be selected only via the date picker, and disables the text input                            |
 
 ### Form.Input Props
 
@@ -93,7 +94,6 @@ More examples [here](https://react-semantic-ui-datepickers.now.sh).
 - size
 - transparent
 - readOnly
-- datePickerOnly
 
 ### Dayzed Props
 

--- a/src/__tests__/datepicker.test.tsx
+++ b/src/__tests__/datepicker.test.tsx
@@ -20,6 +20,8 @@ const setup = (props?: Partial<SemanticDatepickerProps>) => {
       options.rerender(
         <DatePicker onChange={jest.fn()} {...props} {...newProps} />
       ),
+    datePickerInput: options.getByTestId('datepicker-input')
+      .firstChild as HTMLInputElement,
   };
 };
 
@@ -30,9 +32,7 @@ describe('Basic datepicker', () => {
 
   describe('not read only or date picker only', () => {
     it('accepts input', async () => {
-      const { getByTestId } = setup();
-      const datePickerInput = getByTestId('datepicker-input')
-        .firstChild as HTMLInputElement;
+      const { datePickerInput } = setup();
       fireEvent.input(datePickerInput, { target: { value: '23' } });
 
       expect(datePickerInput.value).toBe('23');
@@ -48,20 +48,16 @@ describe('Basic datepicker', () => {
 
   describe('is read only', () => {
     it('does not accept input', async () => {
-      const { getByTestId } = setup({ readOnly: true });
-      const datePickerInput = getByTestId('datepicker-input')
-        .firstChild as HTMLInputElement;
+      const { datePickerInput } = setup({ readOnly: true });
 
       expect(datePickerInput.readOnly).toBeTruthy();
     });
 
     it('does not open date picker', async () => {
-      const { getByTestId, openDatePicker } = setup({ readOnly: true });
+      const { queryByTestId, openDatePicker } = setup({ readOnly: true });
       openDatePicker();
 
-      expect(() => {
-        getByTestId('datepicker-today-button');
-      }).toThrow();
+      expect(queryByTestId('datepicker-today-button')).toBeNull();
     });
   });
 

--- a/src/__tests__/datepicker.test.tsx
+++ b/src/__tests__/datepicker.test.tsx
@@ -28,6 +28,60 @@ describe('Basic datepicker', () => {
     expect(setup()).toBeTruthy();
   });
 
+  describe('not read only or date picker only', () => {
+    it('accepts input', async () => {
+      const { getByTestId } = setup();
+      const datePickerInput = getByTestId('datepicker-input')
+        .firstChild as HTMLInputElement;
+      fireEvent.input(datePickerInput, { target: { value: '23' } });
+
+      expect(datePickerInput.value).toBe('23');
+    });
+
+    it('opens date picker', async () => {
+      const { getByTestId, openDatePicker } = setup();
+      openDatePicker();
+
+      expect(getByTestId('datepicker-today-button')).toBeDefined();
+    });
+  });
+
+  describe('is read only', () => {
+    it('does not accept input', async () => {
+      const { getByTestId } = setup({ readOnly: true });
+      const datePickerInput = getByTestId('datepicker-input')
+        .firstChild as HTMLInputElement;
+
+      expect(datePickerInput.readOnly).toBeTruthy();
+    });
+
+    it('does not open date picker', async () => {
+      const { getByTestId, openDatePicker } = setup({ readOnly: true });
+      openDatePicker();
+
+      expect(() => {
+        getByTestId('datepicker-today-button');
+      }).toThrow();
+    });
+  });
+
+  describe('is date picker only', () => {
+    it('does not accept input', async () => {
+      const { getByTestId } = setup({ readOnly: true });
+      const datePickerInput = getByTestId('datepicker-input')
+        .firstChild as HTMLInputElement;
+
+      expect(datePickerInput.readOnly).toBeTruthy();
+    });
+
+    it('opens date picker', async () => {
+      const { getByTestId, openDatePicker } = setup();
+      openDatePicker();
+
+      expect(getByTestId('datepicker-today-button')).toBeDefined();
+    });
+  });
+
   it('updates the locale if the prop changes', async () => {
     const { getByTestId, openDatePicker, rerender } = setup();
 

--- a/src/components/input.tsx
+++ b/src/components/input.tsx
@@ -14,6 +14,7 @@ const CustomInput = ({
   ...rest
 }: InputProps) => (
   <Form.Input
+    data-testid="datepicker-input"
     {...rest}
     icon={
       <Icon

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -83,6 +83,7 @@ class SemanticDatepicker extends React.Component<
     placeholder: null,
     pointing: 'left',
     readOnly: false,
+    datePickerOnly: false,
     required: false,
     showOutsideDays: false,
     type: 'basic',
@@ -369,7 +370,13 @@ class SemanticDatepicker extends React.Component<
       selectedDateFormatted,
       typedValue,
     } = this.state;
-    const { clearable, pointing, filterDate, readOnly } = this.props;
+    const {
+      clearable,
+      pointing,
+      filterDate,
+      readOnly,
+      datePickerOnly,
+    } = this.props;
 
     return (
       <div className="field" style={style} ref={this.el}>
@@ -382,6 +389,7 @@ class SemanticDatepicker extends React.Component<
           onClick={readOnly ? null : this.showCalendar}
           onKeyDown={this.handleKeyDown}
           value={typedValue || selectedDateFormatted}
+          readOnly={readOnly || datePickerOnly}
         />
         {isVisible && (
           <this.Component

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -69,6 +69,7 @@ export type SemanticDatepickerProps = PickedDayzedProps &
     ) => void;
     pointing: 'left' | 'right' | 'top left' | 'top right';
     type: 'basic' | 'range';
+    datePickerOnly: boolean;
     value: DayzedProps['selected'];
   };
 

--- a/stories/basic.stories.tsx
+++ b/stories/basic.stories.tsx
@@ -28,6 +28,12 @@ export const withReadOnly = () => (
   </Content>
 );
 
+export const withDatePickerOnly = () => (
+  <Content>
+    <SemanticDatepicker onChange={action('selected date')} datePickerOnly />
+  </Content>
+);
+
 export const withoutClearOnSameDateClick = () => (
   <Content>
     <SemanticDatepicker


### PR DESCRIPTION

<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- Is it a bug fix, feature, docs update, ... -->

**What kind of change does this PR introduce?**

Introduce `datePickerOnly` to disable text input of dates and still allow the date to be selected from the date picker.

<!-- You can also link to an open issue here -->

**What is the current behavior?**

`readOnly` disables the text input and the date picker.

<!-- if this is a feature change -->

**What is the new behavior?**

Add `datePickerOnly` to disable text input while still allowing the date to be selected via the date picker.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation
- [x] Tests
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->

<!-- Thank you for contributing! -->
