### PR TITLE
added react hook usage to documentation for further clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ import SemanticDatepicker from 'react-semantic-ui-datepickers';
 import 'react-semantic-ui-datepickers/dist/react-semantic-ui-datepickers.css';
 
 const AppWithBasic = () => {
-  const [currentDate, setNewDate] = useState('');
+  const [currentDate, setNewDate] = useState(null);
   const onChange = (event, data) => setNewDate(data.value);
   <SemanticDatepicker onChange={onChange} />;
 };

--- a/README.md
+++ b/README.md
@@ -51,20 +51,14 @@ import 'react-semantic-ui-datepickers/dist/react-semantic-ui-datepickers.css';
 
 const AppWithBasic = () => {
   const [currentDate, setNewDate] = useState('');
-  const onChange=(event, data) => setNewDate(data.value)
+  const onChange = (event, data) => setNewDate(data.value);
   <SemanticDatepicker onChange={onChange} />;
 };
 
 const AppWithRangeAndInPortuguese = () => {
   const [currentRange, setNewRange] = useState([]);
-  const onChange = (event, data) => setNewRange(data.value)
-  return (
-    <SemanticDatepicker
-      locale="pt-BR"
-      onChange={onChange}
-      type="range"
-    />
-  );
+  const onChange = (event, data) => setNewRange(data.value);
+  return <SemanticDatepicker locale="pt-BR" onChange={onChange} type="range" />;
 };
 ```
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ yarn add react-semantic-ui-datepickers
 ## Usage
 
 ```jsx
-import React from 'react';
+import React, { useState } from 'react';
 import SemanticDatepicker from 'react-semantic-ui-datepickers';
 import 'react-semantic-ui-datepickers/dist/react-semantic-ui-datepickers.css';
 
@@ -56,6 +56,16 @@ const AppWithBasic = ({ onChange }) => (
 const AppWithRangeAndInPortuguese = ({ onChange }) => (
   <SemanticDatepicker locale="pt-BR" onChange={onChange} type="range" />
 );
+
+const WithReactHook = () => {
+  const [currentDate, setNewDate] = useState('');
+  return (
+    <div>
+      <SemanticDatepicker onChange={(event, date) => setNewDate(date.value)} />
+      <p>Date selected: {currentDate.toString()}</p>
+    </div>
+  );
+};
 ```
 
 More examples [here](https://react-semantic-ui-datepickers.now.sh).

--- a/README.md
+++ b/README.md
@@ -51,15 +51,17 @@ import 'react-semantic-ui-datepickers/dist/react-semantic-ui-datepickers.css';
 
 const AppWithBasic = () => {
   const [currentDate, setNewDate] = useState('');
-  <SemanticDatepicker onChange={(event, data) => setNewDate(data.value)} />;
+  const onChange=(event, data) => setNewDate(data.value)
+  <SemanticDatepicker onChange={onChange} />;
 };
 
 const AppWithRangeAndInPortuguese = () => {
   const [currentRange, setNewRange] = useState([]);
+  const onChange = (event, data) => setNewRange(data.value)
   return (
     <SemanticDatepicker
       locale="pt-BR"
-      onChange={(event, data) => setNewRange(data.value)}
+      onChange={onChange}
       type="range"
     />
   );

--- a/README.md
+++ b/README.md
@@ -49,21 +49,19 @@ import React, { useState } from 'react';
 import SemanticDatepicker from 'react-semantic-ui-datepickers';
 import 'react-semantic-ui-datepickers/dist/react-semantic-ui-datepickers.css';
 
-const AppWithBasic = ({ onChange }) => (
-  <SemanticDatepicker onChange={onChange} />
-);
-
-const AppWithRangeAndInPortuguese = ({ onChange }) => (
-  <SemanticDatepicker locale="pt-BR" onChange={onChange} type="range" />
-);
-
-const WithReactHook = () => {
+const AppWithBasic = () => {
   const [currentDate, setNewDate] = useState('');
+  <SemanticDatepicker onChange={(event, data) => setNewDate(data.value)} />;
+};
+
+const AppWithRangeAndInPortuguese = () => {
+  const [currentRange, setNewRange] = useState([]);
   return (
-    <div>
-      <SemanticDatepicker onChange={(event, date) => setNewDate(date.value)} />
-      <p>Date selected: {currentDate.toString()}</p>
-    </div>
+    <SemanticDatepicker
+      locale="pt-BR"
+      onChange={(event, data) => setNewRange(data.value)}
+      type="range"
+    />
   );
 };
 ```


### PR DESCRIPTION
This is to add to the documentation an example of react hook for usage and add clarity to how the date is retrieved with params `(event, date)` and displayed from property `value` via `data.value`

Closes #144.