### PR TITLE
fix(rollup): fix destination path for CSS file

### DIFF
--- a/tsdx.config.js
+++ b/tsdx.config.js
@@ -16,7 +16,7 @@ module.exports = {
         inject: true,
         // only write out CSS for the first bundle (avoids pointless extra files):
         extract: options.writeMeta
-          ? 'dist/react-semantic-ui-datepickers.css'
+          ? 'react-semantic-ui-datepickers.css'
           : false,
       })
     );


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- Is it a bug fix, feature, docs update, ... -->

**What kind of change does this PR introduce?**

Build fix.

**What is the current behavior?**

`rollup-plugin-postcss` was updated and the new major version changes how the path for the CSS file is constructed. Therefore, we don't need to specify the `dist` folder anymore.

**What is the new behavior?**

The build config is fixed.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [ ] Tests
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->

<!-- Thank you for contributing! -->
