### PR TITLE
fix(datepicker): allow empty string as placeholder

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "module": "dist/react-semantic-ui-datepickers.esm.js",
   "typings": "dist/index.d.ts",
   "scripts": {
-    "lint": "tsdx lint src",
+    "lint": "tsdx lint src stories",
+    "lint:fix": "yarn lint --fix",
     "start": "tsdx watch",
     "build": "tsdx build",
     "prebuild": "rimraf dist",

--- a/src/__tests__/datepicker.test.tsx
+++ b/src/__tests__/datepicker.test.tsx
@@ -266,6 +266,26 @@ describe('Basic datepicker', () => {
       expect(onBlur).not.toHaveBeenCalled();
     });
   });
+
+  describe('placeholder', () => {
+    it('should use the format prop as default', () => {
+      const { datePickerInput } = setup();
+
+      expect(datePickerInput.placeholder).toBe('YYYY-MM-DD');
+    });
+
+    it('should allow empty strings', () => {
+      const { datePickerInput } = setup({ placeholder: '' });
+
+      expect(datePickerInput.placeholder).toBe('');
+    });
+
+    it('should allow null', () => {
+      const { datePickerInput } = setup({ placeholder: null });
+
+      expect(datePickerInput.placeholder).toBe('');
+    });
+  });
 });
 
 describe('Range datepicker', () => {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -83,7 +83,7 @@ class SemanticDatepicker extends React.Component<
     name: undefined,
     onBlur: () => {},
     onChange: () => {},
-    placeholder: null,
+    placeholder: undefined,
     pointing: 'left',
     readOnly: false,
     datePickerOnly: false,
@@ -131,7 +131,8 @@ class SemanticDatepicker extends React.Component<
 
   get inputProps() {
     const props = pick(semanticInputProps, this.props);
-    const placeholder = props.placeholder || this.props.format;
+    const placeholder =
+      props.placeholder !== undefined ? props.placeholder : this.props.format;
 
     return {
       ...props,

--- a/stories/basic.stories.tsx
+++ b/stories/basic.stories.tsx
@@ -6,7 +6,7 @@ import SemanticDatepicker from '../src';
 import { Content } from './common';
 import { parseISO } from 'date-fns';
 
-const isWeekday = date => {
+const isWeekday = (date: Date) => {
   const day = date.getDay();
 
   return day !== 0 && day !== 6;


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- Is it a bug fix, feature, docs update, ... -->

**What kind of change does this PR introduce?**
Bug fix. Closes #260.
<!-- You can also link to an open issue here -->

**What is the current behavior?**
`placeholder` prop is overridden with it's an empty string or `null`.
<!-- if this is a feature change -->

**What is the new behavior?**
If the `placeholder` prop is different from `undefined`, it's applied. Otherwise, we use the `format` prop as placeholder.
<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation
- [x] Tests
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->

<!-- Thank you for contributing! -->
