### PR TITLE
fix(datepicker): apply id on label's htmlFor attribute

### DIFF
--- a/src/__tests__/datepicker.test.tsx
+++ b/src/__tests__/datepicker.test.tsx
@@ -236,6 +236,16 @@ describe('Basic datepicker', () => {
     expect(datePickerInput.value).toBe('');
   });
 
+  it('should be accessible when id is provided', () => {
+    const { getByLabelText, getByText } = setup({
+      id: 'click-me',
+      label: 'Click me',
+    });
+
+    fireEvent.click(getByLabelText('Click me'));
+    expect(getByText('Today')).toBeTruthy();
+  });
+
   describe('clearOnSameDateClick', () => {
     it('reset its state when prop is true', () => {
       const { datePickerInput, getByText, openDatePicker } = setup({

--- a/src/components/input.tsx
+++ b/src/components/input.tsx
@@ -18,7 +18,7 @@ const CustomInput = React.forwardRef<Input, InputProps>((props, ref) => {
 
   return (
     <Form.Field>
-      {label && <label>{label}</label>}
+      {label && <label htmlFor={rest.id as string | undefined}>{label}</label>}
       <Input
         data-testid="datepicker-input"
         {...rest}


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- Is it a bug fix, feature, docs update, ... -->

**What kind of change does this PR introduce?**
Bug fix.
<!-- You can also link to an open issue here -->

**What is the current behavior?**
When provided, the `id` prop is not applied on the `label`'s `htmlFor` attribute.
<!-- if this is a feature change -->

**What is the new behavior?**
The `id` is applied and therefore, the label is now accessible.
<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [x] Tests
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->

<!-- Thank you for contributing! -->
