### PR TITLE
feat: support custom icon and clearIcon props

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,31 +73,32 @@ More examples [here](https://react-semantic-ui-datepickers.now.sh).
 
 ### Own Props
 
-| property             | type         | required | default      | description                                                                                                     |
-| -------------------- | ------------ | -------- | ------------ | --------------------------------------------------------------------------------------------------------------- |
-| allowOnlyNumbers     | boolean      | no       | true         | Allows the user enter only numbers                                                                              |
-| autoComplete         | string       | no       | --           | Specifies if the input should have autocomplete enabled                                                         |
-| clearOnSameDateClick | boolean      | no       | true         | Controls whether the datepicker's state resets if the same date is selected in succession.                      |
-| clearable            | boolean      | no       | true         | Allows the user to clear the value                                                                              |
-| filterDate           | function     | no       | () => true   | Function that receives each date and returns a boolean to indicate whether it is enabled or not                 |
-| format               | string       | no       | 'YYYY-MM-DD' | Specifies how the date will be formatted using the [date-fns' format](https://date-fns.org/v1.29.0/docs/format) |
-| keepOpenOnClear      | boolean      | no       | false        | Keeps the datepicker open (or opens it if it's closed) when the clear icon is clicked                           |
-| keepOpenOnSelect     | boolean      | no       | false        | Keeps the datepicker open when a date is selected                                                               |
-| inline               | boolean      | no       | false        | Uses an inline variant, without the input and the features related to it, e.g. clearable datepicker             |
-| locale               | string       | no       | 'en-US'      | Filename of the locale to be used. PS: Feel free to submit PR's with more locales!                              |
-| onBlur               | function     | no       | () => {}     | Callback fired when the input loses focus                                                                       |
-| onChange             | function     | no       | () => {}     | Callback fired when the value changes                                                                           |
-| pointing             | string       | no       | 'left'       | Location to render the component around input. Available options: 'left', 'right', 'top left', 'top right'      |
-| type                 | string       | no       | basic        | Type of input to render. Available options: 'basic' and 'range'                                                 |
-| datePickerOnly       | boolean      | no       | false        | Allows the date to be selected only via the date picker and disables the text input                             |
-| value                | Date\|Date[] | no       | --           | The value of the datepicker                                                                                     |
+| property             | type                                | required | default      | description                                                                                                                                                                 |
+| -------------------- | ----------------------------------- | -------- | ------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| allowOnlyNumbers     | boolean                             | no       | true         | Allows the user enter only numbers                                                                                                                                          |
+| autoComplete         | string                              | no       | --           | Specifies if the input should have autocomplete enabled                                                                                                                     |
+| clearIcon            | SemanticICONS \| React.ReactElement | no       | 'close'      | An [icon from semantic-ui-react](https://react.semantic-ui.com/elements/icon/) or a custom component. The custom component will get two props: `data-testid` and `onClick`. |
+| clearOnSameDateClick | boolean                             | no       | true         | Controls whether the datepicker's state resets if the same date is selected in succession.                                                                                  |
+| clearable            | boolean                             | no       | true         | Allows the user to clear the value                                                                                                                                          |
+| datePickerOnly       | boolean                             | no       | false        | Allows the date to be selected only via the date picker and disables the text input                                                                                         |
+| filterDate           | function                            | no       | () => true   | Function that receives each date and returns a boolean to indicate whether it is enabled or not                                                                             |
+| format               | string                              | no       | 'YYYY-MM-DD' | Specifies how the date will be formatted using the [date-fns' format](https://date-fns.org/v1.29.0/docs/format)                                                             |
+| icon                 | SemanticICONS \| React.ReactElement | no       | 'calendar'   | An [icon from semantic-ui-react](https://react.semantic-ui.com/elements/icon/) or a custom component. The custom component will get two props: `data-testid` and `onClick`. |
+| inline               | boolean                             | no       | false        | Uses an inline variant, without the input and the features related to it, e.g. clearable datepicker                                                                         |
+| keepOpenOnClear      | boolean                             | no       | false        | Keeps the datepicker open (or opens it if it's closed) when the clear icon is clicked                                                                                       |
+| keepOpenOnSelect     | boolean                             | no       | false        | Keeps the datepicker open when a date is selected                                                                                                                           |
+| locale               | string                              | no       | 'en-US'      | Filename of the locale to be used. PS: Feel free to submit PR's with more locales!                                                                                          |
+| onBlur               | function                            | no       | () => {}     | Callback fired when the input loses focus                                                                                                                                   |
+| onChange             | function                            | no       | () => {}     | Callback fired when the value changes                                                                                                                                       |
+| pointing             | string                              | no       | 'left'       | Location to render the component around input. Available options: 'left', 'right', 'top left', 'top right'                                                                  |
+| type                 | string                              | no       | basic        | Type of input to render. Available options: 'basic' and 'range'                                                                                                             |
+| value                | Date\|Date[]                        | no       | --           | The value of the datepicker                                                                                                                                                 |
 
 ### Form.Input Props
 
 - autoComplete
 - disabled
 - error
-- icon
 - iconPosition
 - id
 - label

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "@storybook/addon-links": "5.3.19",
     "@storybook/addons": "5.3.19",
     "@storybook/react": "5.3.19",
+    "@testing-library/jest-dom": "5.10.1",
     "@testing-library/react": "10.2.1",
     "@types/jest": "26.0.0",
     "@types/storybook__react": "5.2.1",
@@ -84,6 +85,7 @@
         "tsConfig": "tsconfig.test.json"
       }
     },
+    "setupFilesAfterEnv": ["./jest.setup.ts"],
     "transform": {
       ".+\\.css$": "jest-transform-css",
       ".(js|ts)x?": "ts-jest"

--- a/src/__tests__/datepicker.test.tsx
+++ b/src/__tests__/datepicker.test.tsx
@@ -490,14 +490,34 @@ describe('Inline datepicker', () => {
   describe('Custom icons', () => {
     it('should allow for custom Semantic UI icons', () => {
       const icon = 'search';
-      const { getIcon } = setup({ icon });
+      const { getByText, getIcon, openDatePicker } = setup({ icon });
 
+      // Assert custom icon
+      expect(getIcon()).toHaveClass(icon, 'icon');
+      // Select current date
+      openDatePicker();
+      fireEvent.click(getByText('Today'));
+      // Assert datepicker is clearable
+      expect(getIcon()).toHaveClass('close', 'icon');
+      fireEvent.click(getIcon());
+      // Assert datepicker was cleared
       expect(getIcon()).toHaveClass(icon, 'icon');
     });
 
     it('should allow for custom icon components', () => {
-      const { getIcon } = setup({ icon: <span>Custom icon</span> });
+      const { getByText, getIcon, openDatePicker } = setup({
+        icon: <span>Custom icon</span>,
+      });
 
+      // Assert custom icon
+      expect(getIcon().textContent).toBe('Custom icon');
+      // Select current date
+      openDatePicker();
+      fireEvent.click(getByText('Today'));
+      // Assert datepicker is clearable
+      expect(getIcon()).toHaveClass('close', 'icon');
+      fireEvent.click(getIcon());
+      // Assert datepicker was cleared
       expect(getIcon().textContent).toBe('Custom icon');
     });
 
@@ -505,10 +525,15 @@ describe('Inline datepicker', () => {
       const clearIcon = 'ban';
       const { getByText, getIcon, openDatePicker } = setup({ clearIcon });
 
+      // Select current date
       openDatePicker();
       fireEvent.click(getByText('Today'));
-
+      // Assert custom icon
       expect(getIcon()).toHaveClass(clearIcon, 'icon');
+      // Assert datepicker is clearable
+      fireEvent.click(getIcon());
+      // Assert datepicker was cleared
+      expect(getIcon()).toHaveClass('calendar', 'icon');
     });
 
     it('should allow for custom clear icon components', () => {
@@ -517,10 +542,15 @@ describe('Inline datepicker', () => {
         clearIcon: customClearIcon,
       });
 
+      // Select current date
       openDatePicker();
       fireEvent.click(getByText('Today'));
-
+      // Assert custom icon
       expect(getIcon().textContent).toBe('Custom icon');
+      // Assert datepicker is clearable
+      fireEvent.click(getIcon());
+      // Assert datepicker was cleared
+      expect(getIcon()).toHaveClass('calendar', 'icon');
     });
   });
 });

--- a/src/__tests__/datepicker.test.tsx
+++ b/src/__tests__/datepicker.test.tsx
@@ -9,14 +9,12 @@ import DatePicker from '../';
 const setup = (props: Partial<SemanticDatepickerProps> = {}) => {
   const options = render(<DatePicker onChange={jest.fn()} {...props} />);
   const getQuery = props.inline ? options.queryByTestId : options.getByTestId;
+  const getIcon = () => options.getByTestId('datepicker-icon');
 
   return {
     ...options,
-    openDatePicker: () => {
-      const icon = options.getByTestId('datepicker-icon');
-
-      fireEvent.click(icon);
-    },
+    getIcon,
+    openDatePicker: () => fireEvent.click(getIcon()),
     rerender: (newProps?: Partial<SemanticDatepickerProps>) =>
       options.rerender(
         <DatePicker onChange={jest.fn()} {...props} {...newProps} />
@@ -486,6 +484,43 @@ describe('Inline datepicker', () => {
           value: [expect.any(Date), expect.any(Date)],
         })
       );
+    });
+  });
+
+  describe('Custom icons', () => {
+    it('should allow for custom Semantic UI icons', () => {
+      const icon = 'search';
+      const { getIcon } = setup({ icon });
+
+      expect(getIcon()).toHaveClass(icon, 'icon');
+    });
+
+    it('should allow for custom icon components', () => {
+      const { getIcon } = setup({ icon: <span>Custom icon</span> });
+
+      expect(getIcon().textContent).toBe('Custom icon');
+    });
+
+    it('should allow for custom clear Semantic UI icons', () => {
+      const clearIcon = 'ban';
+      const { getByText, getIcon, openDatePicker } = setup({ clearIcon });
+
+      openDatePicker();
+      fireEvent.click(getByText('Today'));
+
+      expect(getIcon()).toHaveClass(clearIcon, 'icon');
+    });
+
+    it('should allow for custom clear icon components', () => {
+      const customClearIcon = <span>Custom icon</span>;
+      const { getByText, getIcon, openDatePicker } = setup({
+        clearIcon: customClearIcon,
+      });
+
+      openDatePicker();
+      fireEvent.click(getByText('Today'));
+
+      expect(getIcon().textContent).toBe('Custom icon');
     });
   });
 });

--- a/src/components/icon.tsx
+++ b/src/components/icon.tsx
@@ -17,14 +17,14 @@ const CustomIcon = ({
   onClear,
   onClick,
 }: CustomIconProps) => {
-  if (isClearIconVisible && clearIcon && typeof clearIcon !== 'string') {
+  if (isClearIconVisible && clearIcon && React.isValidElement(clearIcon)) {
     return React.cloneElement(clearIcon, {
       'data-testid': 'datepicker-icon',
       onClick: onClear,
     });
   }
 
-  if (isClearIconVisible && clearIcon && typeof clearIcon === 'string') {
+  if (isClearIconVisible && clearIcon && !React.isValidElement(clearIcon)) {
     return (
       <SUIIcon
         data-testid="datepicker-icon"
@@ -35,7 +35,7 @@ const CustomIcon = ({
     );
   }
 
-  if (icon && typeof icon !== 'string') {
+  if (icon && React.isValidElement(icon)) {
     return React.cloneElement(icon, {
       'data-testid': 'datepicker-icon',
       onClick,

--- a/src/components/icon.tsx
+++ b/src/components/icon.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { Icon as SUIIcon } from 'semantic-ui-react';
+import { SemanticDatepickerProps } from '../types';
+
+type CustomIconProps = {
+  clearIcon: SemanticDatepickerProps['clearIcon'];
+  icon: SemanticDatepickerProps['icon'];
+  isClearIconVisible: boolean;
+  onClear: () => void;
+  onClick: () => void;
+};
+
+const CustomIcon = ({
+  clearIcon,
+  icon,
+  isClearIconVisible,
+  onClear,
+  onClick,
+}: CustomIconProps) => {
+  if (isClearIconVisible && clearIcon && typeof clearIcon !== 'string') {
+    return React.cloneElement(clearIcon, {
+      'data-testid': 'datepicker-icon',
+      onClick: onClear,
+    });
+  }
+
+  if (isClearIconVisible && clearIcon && typeof clearIcon === 'string') {
+    return (
+      <SUIIcon
+        data-testid="datepicker-icon"
+        link
+        name={clearIcon}
+        onClick={onClear}
+      />
+    );
+  }
+
+  if (icon && typeof icon !== 'string') {
+    return React.cloneElement(icon, {
+      'data-testid': 'datepicker-icon',
+      onClick,
+    });
+  }
+
+  return (
+    <SUIIcon data-testid="datepicker-icon" link name={icon} onClick={onClick} />
+  );
+};
+
+CustomIcon.defaultProps = {
+  clearIcon: 'close',
+  icon: 'calendar',
+};
+
+export default CustomIcon;

--- a/src/components/input.tsx
+++ b/src/components/input.tsx
@@ -1,12 +1,17 @@
 import React from 'react';
-import { Form, Icon, Input, FormInputProps } from 'semantic-ui-react';
+import { Form, Input, FormInputProps } from 'semantic-ui-react';
+import { SemanticDatepickerProps } from '../types';
+import CustomIcon from './icon';
 
 type InputProps = FormInputProps & {
+  clearIcon: SemanticDatepickerProps['clearIcon'];
+  icon: SemanticDatepickerProps['icon'];
   isClearIconVisible: boolean;
 };
 
 const CustomInput = React.forwardRef<Input, InputProps>((props, ref) => {
   const {
+    clearIcon,
     icon,
     isClearIconVisible,
     label,
@@ -24,11 +29,12 @@ const CustomInput = React.forwardRef<Input, InputProps>((props, ref) => {
         {...rest}
         ref={ref}
         icon={
-          <Icon
-            data-testid="datepicker-icon"
-            link
-            name={isClearIconVisible ? 'close' : icon}
-            onClick={isClearIconVisible ? onClear : onClick}
+          <CustomIcon
+            clearIcon={clearIcon}
+            icon={icon}
+            isClearIconVisible={isClearIconVisible}
+            onClear={onClear}
+            onClick={onClick}
           />
         }
         onClick={onClick}
@@ -37,9 +43,5 @@ const CustomInput = React.forwardRef<Input, InputProps>((props, ref) => {
     </Form.Field>
   );
 });
-
-CustomInput.defaultProps = {
-  icon: 'calendar',
-};
 
 export default CustomInput;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -23,6 +23,7 @@ const style: React.CSSProperties = {
 };
 const semanticInputProps = [
   'autoComplete',
+  'clearIcon',
   'disabled',
   'error',
   'icon',

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,4 +1,4 @@
-import { FormInputProps } from 'semantic-ui-react';
+import { FormInputProps, SemanticICONS } from 'semantic-ui-react';
 
 export type Object = { [key: string]: any };
 
@@ -41,7 +41,6 @@ export type PickedFormInputProps = Pick<
   FormInputProps,
   | 'disabled'
   | 'error'
-  | 'icon'
   | 'iconPosition'
   | 'id'
   | 'label'
@@ -59,10 +58,12 @@ export type SemanticDatepickerProps = PickedDayzedProps &
     autoComplete?: string;
     clearOnSameDateClick: boolean;
     clearable: boolean;
+    clearIcon?: SemanticICONS | React.ReactElement;
     filterDate: (date: Date) => boolean;
     format: string;
     keepOpenOnClear: boolean;
     keepOpenOnSelect: boolean;
+    icon?: SemanticICONS | React.ReactElement;
     inline: boolean;
     locale: LocaleOptions;
     onBlur: (event?: React.SyntheticEvent) => void;

--- a/stories/data.ts
+++ b/stories/data.ts
@@ -39,6 +39,6 @@ export const pointingMap = arrayToMap(pointing);
 
 export const localeMap = arrayToMap([...locale].sort());
 
-export const iconMap = arrayToMap(ALL_ICONS_IN_ALL_CONTEXTS.sort()) as {
-  [key in SemanticICONS]: SemanticICONS;
-};
+export const iconMap = arrayToMap<SemanticICONS>(
+  ALL_ICONS_IN_ALL_CONTEXTS.sort()
+);

--- a/stories/data.ts
+++ b/stories/data.ts
@@ -1,3 +1,6 @@
+import { ALL_ICONS_IN_ALL_CONTEXTS } from 'semantic-ui-react/src/lib/SUI';
+import { SemanticICONS } from 'semantic-ui-react';
+
 const types = <const>['basic', 'range'];
 const pointing = <const>['left', 'right', 'top left', 'top right'];
 const locale = <const>[
@@ -35,3 +38,7 @@ export const typeMap = arrayToMap(types);
 export const pointingMap = arrayToMap(pointing);
 
 export const localeMap = arrayToMap([...locale].sort());
+
+export const iconMap = arrayToMap(ALL_ICONS_IN_ALL_CONTEXTS.sort()) as {
+  [key in SemanticICONS]: SemanticICONS;
+};

--- a/stories/index.stories.tsx
+++ b/stories/index.stories.tsx
@@ -8,7 +8,7 @@ import {
   text,
 } from '@storybook/addon-knobs';
 import { storiesOf } from '@storybook/react';
-import { Form } from 'semantic-ui-react';
+import { Form, SemanticICONS } from 'semantic-ui-react';
 import 'semantic-ui-css/semantic.min.css';
 import SemanticDatepicker from '../src';
 import {
@@ -41,6 +41,7 @@ stories.add('Basic usage', () => {
   const clearable = boolean('Clearable', true);
   const icon = select('Icon (without value)', iconMap, iconMap.calendar);
   const clearIcon = select('Clear icon (with value)', iconMap, iconMap.close);
+  const iconOnLeft = boolean('Icon on the left', false);
   const datePickerOnly = boolean('Datepicker only', false);
   const firstDayOfWeek = number('First day of week', 0, { max: 6, min: 0 });
   const format = text('Format', 'YYYY-MM-DD');
@@ -75,6 +76,7 @@ stories.add('Basic usage', () => {
         firstDayOfWeek={firstDayOfWeek}
         format={format}
         icon={icon}
+        iconPosition={iconOnLeft ? 'left' : undefined}
         inline={inline}
         keepOpenOnClear={keepOpenOnClear}
         keepOpenOnSelect={keepOpenOnSelect}
@@ -87,6 +89,26 @@ stories.add('Basic usage', () => {
         showOutsideDays={showOutsideDays}
         type={type}
         value={initialValue}
+      />
+    </Content>
+  );
+});
+
+stories.add('With custom icons', () => {
+  const icon = select('Icon (without value)', iconMap, iconMap.calendar);
+  const clearIcon = select('Clear icon (with value)', iconMap, iconMap.close);
+  const useCustomIcon = boolean('Custom icon', false);
+  const useCustomClearIcon = boolean('Custom clear icon', false);
+  const CustomIcon = (props: any) => <button {...props}>Select</button>;
+  const CustomClearIcon = (props: any) => <button {...props}>Reset</button>;
+  const x = useCustomIcon ? ((<CustomIcon />) as unknown) : icon;
+  const y = useCustomClearIcon ? ((<CustomClearIcon />) as unknown) : clearIcon;
+
+  return (
+    <Content>
+      <SemanticDatepicker
+        clearIcon={y as SemanticICONS | React.ReactElement}
+        icon={x as SemanticICONS | React.ReactElement}
       />
     </Content>
   );

--- a/stories/index.stories.tsx
+++ b/stories/index.stories.tsx
@@ -13,6 +13,7 @@ import 'semantic-ui-css/semantic.min.css';
 import SemanticDatepicker from '../src';
 import {
   Content,
+  iconMap,
   isWeekday,
   localeMap,
   onChange,
@@ -37,6 +38,9 @@ stories.add('Basic usage', () => {
   const inline = boolean('Inline (without input)', false);
   const allowOnlyNumbers = boolean('Allow only numbers', false);
   const clearOnSameDateClick = boolean('Clear on same date click', true);
+  const clearable = boolean('Clearable', true);
+  const icon = select('Icon (without value)', iconMap, iconMap.calendar);
+  const clearIcon = select('Clear icon (with value)', iconMap, iconMap.close);
   const datePickerOnly = boolean('Datepicker only', false);
   const firstDayOfWeek = number('First day of week', 0, { max: 6, min: 0 });
   const format = text('Format', 'YYYY-MM-DD');
@@ -44,7 +48,6 @@ stories.add('Basic usage', () => {
   const keepOpenOnSelect = boolean('Keep open on select', false);
   const locale = select('Locale', localeMap, localeMap['en-US']);
   const pointing = select('Pointing', pointingMap, pointingMap.left);
-  const clearable = boolean('Clearable', true);
   const readOnly = boolean('Read-only', false);
   const showOutsideDays = boolean('Show outside days', false);
   const minDate = new Date(date('Min date', new Date('2018-01-01')));
@@ -64,15 +67,17 @@ stories.add('Basic usage', () => {
       <SemanticDatepicker
         key={key}
         allowOnlyNumbers={allowOnlyNumbers}
+        clearIcon={clearIcon}
         clearOnSameDateClick={clearOnSameDateClick}
         clearable={clearable}
         datePickerOnly={datePickerOnly}
         filterDate={filterDate}
         firstDayOfWeek={firstDayOfWeek}
         format={format}
+        icon={icon}
+        inline={inline}
         keepOpenOnClear={keepOpenOnClear}
         keepOpenOnSelect={keepOpenOnSelect}
-        inline={inline}
         locale={locale}
         maxDate={maxDate}
         minDate={minDate}

--- a/yarn.lock
+++ b/yarn.lock
@@ -914,7 +914,7 @@
     core-js-pure "^3.0.0"
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@7.10.2", "@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.10.2", "@babel/runtime@^7.3.1", "@babel/runtime@^7.4.4", "@babel/runtime@^7.4.5", "@babel/runtime@^7.5.0", "@babel/runtime@^7.5.5", "@babel/runtime@^7.6.2", "@babel/runtime@^7.6.3", "@babel/runtime@^7.7.2", "@babel/runtime@^7.7.4", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.7":
+"@babel/runtime@7.10.2", "@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.10.2", "@babel/runtime@^7.3.1", "@babel/runtime@^7.4.4", "@babel/runtime@^7.4.5", "@babel/runtime@^7.5.0", "@babel/runtime@^7.5.5", "@babel/runtime@^7.6.2", "@babel/runtime@^7.6.3", "@babel/runtime@^7.7.2", "@babel/runtime@^7.7.4", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.7", "@babel/runtime@^7.9.2":
   version "7.10.2"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.10.2.tgz#d103f21f2602497d38348a32e008637d506db839"
   integrity sha512-6sF3uQw2ivImfVIl62RZ7MXhO2tap69WeWK57vAaimT6AZbE4FbqjdEJIN1UqoD6wI6B+1n9UiagafH1sxjOtg==
@@ -1881,6 +1881,21 @@
     dom-accessibility-api "^0.4.5"
     pretty-format "^25.5.0"
 
+"@testing-library/jest-dom@5.10.1":
+  version "5.10.1"
+  resolved "https://registry.yarnpkg.com/@testing-library/jest-dom/-/jest-dom-5.10.1.tgz#6508a9f007bd74e5d3c0b3135b668027ab663989"
+  integrity sha512-uv9lLAnEFRzwUTN/y9lVVXVXlEzazDkelJtM5u92PsGkEasmdI+sfzhZHxSDzlhZVTrlLfuMh2safMr8YmzXLg==
+  dependencies:
+    "@babel/runtime" "^7.9.2"
+    "@types/testing-library__jest-dom" "^5.9.1"
+    chalk "^3.0.0"
+    css "^2.2.4"
+    css.escape "^1.5.1"
+    jest-diff "^25.1.0"
+    jest-matcher-utils "^25.1.0"
+    lodash "^4.17.15"
+    redent "^3.0.0"
+
 "@testing-library/react@10.2.1":
   version "10.2.1"
   resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-10.2.1.tgz#f0c5ac9072ad54c29672150943f35d6617263f26"
@@ -1988,7 +2003,7 @@
     "@types/istanbul-lib-coverage" "*"
     "@types/istanbul-lib-report" "*"
 
-"@types/jest@26.0.0":
+"@types/jest@*", "@types/jest@26.0.0":
   version "26.0.0"
   resolved "https://registry.yarnpkg.com/@types/jest/-/jest-26.0.0.tgz#a6d7573dffa9c68cbbdf38f2e0de26f159e11134"
   integrity sha512-/yeMsH9HQ1RLORlXAwoLXe8S98xxvhNtUz3yrgrwbaxYjT+6SFPZZRksmRKRA6L5vsUtSHeN71viDOTTyYAD+g==
@@ -2093,6 +2108,13 @@
   integrity sha512-p4QGO+VjEO3YxyWVHpPylNheA0JhStzoCg6RBTmdobrC0ZqLPEIIWu0pFkHlNkmGIiEKW2yDGFJooBe8M4Df0Q==
   dependencies:
     "@storybook/react" "*"
+
+"@types/testing-library__jest-dom@^5.9.1":
+  version "5.9.1"
+  resolved "https://registry.yarnpkg.com/@types/testing-library__jest-dom/-/testing-library__jest-dom-5.9.1.tgz#aba5ee062b7880f69c212ef769389f30752806e5"
+  integrity sha512-yYn5EKHO3MPEMSOrcAb1dLWY+68CG29LiXKsWmmpVHqoP5+ZRiAVLyUHvPNrO2dABDdUGZvavMsaGpWNjM6N2g==
+  dependencies:
+    "@types/jest" "*"
 
 "@types/webpack-env@^1.15.0":
   version "1.15.0"
@@ -2745,7 +2767,7 @@ asyncro@^3.0.0:
   resolved "https://registry.yarnpkg.com/asyncro/-/asyncro-3.0.0.tgz#3c7a732e263bc4a42499042f48d7d858e9c0134e"
   integrity sha512-nEnWYfrBmA3taTiuiOoZYmgJ/CNrSoQLeLs29SeLcPu60yaw/mHDBHV0iOZ051fTvsTHxpCY+gXibqT9wbQYfg==
 
-atob@^2.1.1:
+atob@^2.1.1, atob@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.2.tgz#6d9517eb9e030d2436666651e86bd9f6f13533c9"
   integrity sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==
@@ -4322,6 +4344,21 @@ css-what@2.1, css-what@^2.1.2:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/css-what/-/css-what-2.1.3.tgz#a6d7604573365fe74686c3f311c56513d88285f2"
   integrity sha512-a+EPoD+uZiNfh+5fxw2nO9QwFa6nJe2Or35fGY6Ipw1R3R4AGz1d1TEZrCegvw2YTmZ0jXirGYlzxxpYSHwpEg==
+
+css.escape@^1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/css.escape/-/css.escape-1.5.1.tgz#42e27d4fa04ae32f931a4b4d4191fa9cddee97cb"
+  integrity sha1-QuJ9T6BK4y+TGktNQZH6nN3ul8s=
+
+css@^2.2.4:
+  version "2.2.4"
+  resolved "https://registry.yarnpkg.com/css/-/css-2.2.4.tgz#c646755c73971f2bba6a601e2cf2fd71b1298929"
+  integrity sha512-oUnjmWpy0niI3x/mPL8dVEI1l7MnG3+HHyRPHf+YFSbK+svOhXpmSOcDURUh2aOCgl2grzrOPt1nHLuCVFULLw==
+  dependencies:
+    inherits "^2.0.3"
+    source-map "^0.6.1"
+    source-map-resolve "^0.5.2"
+    urix "^0.1.0"
 
 cssesc@^0.1.0:
   version "0.1.0"
@@ -7274,6 +7311,16 @@ jest-diff@^24.3.0, jest-diff@^24.9.0:
     jest-get-type "^24.9.0"
     pretty-format "^24.9.0"
 
+jest-diff@^25.1.0, jest-diff@^25.5.0:
+  version "25.5.0"
+  resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-25.5.0.tgz#1dd26ed64f96667c068cef026b677dfa01afcfa9"
+  integrity sha512-z1kygetuPiREYdNIumRpAHY6RXiGmp70YHptjdaxTWGmA085W3iCnXNx0DhflK3vwrKmrRWyY1wUpkPMVxMK7A==
+  dependencies:
+    chalk "^3.0.0"
+    diff-sequences "^25.2.6"
+    jest-get-type "^25.2.6"
+    pretty-format "^25.5.0"
+
 jest-diff@^25.2.1:
   version "25.4.0"
   resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-25.4.0.tgz#260b70f19a46c283adcad7f081cae71eb784a634"
@@ -7393,6 +7440,16 @@ jest-matcher-utils@^24.9.0:
     jest-diff "^24.9.0"
     jest-get-type "^24.9.0"
     pretty-format "^24.9.0"
+
+jest-matcher-utils@^25.1.0:
+  version "25.5.0"
+  resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-25.5.0.tgz#fbc98a12d730e5d2453d7f1ed4a4d948e34b7867"
+  integrity sha512-VWI269+9JS5cpndnpCwm7dy7JtGQT30UHfrnM3mXl22gHGt/b7NkjBqXfbhZ8V4B7ANUsjK18PlSBmG0YH7gjw==
+  dependencies:
+    chalk "^3.0.0"
+    jest-diff "^25.5.0"
+    jest-get-type "^25.2.6"
+    pretty-format "^25.5.0"
 
 jest-message-util@^24.9.0:
   version "24.9.0"
@@ -10507,6 +10564,14 @@ recursive-readdir@2.2.2:
   dependencies:
     minimatch "3.0.4"
 
+redent@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/redent/-/redent-3.0.0.tgz#e557b7998316bb53c9f1f56fa626352c6963059f"
+  integrity sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==
+  dependencies:
+    indent-string "^4.0.0"
+    strip-indent "^3.0.0"
+
 refractor@^2.4.1:
   version "2.10.0"
   resolved "https://registry.yarnpkg.com/refractor/-/refractor-2.10.0.tgz#4cc7efc0028a87924a9b31d82d129dec831a287b"
@@ -11387,6 +11452,17 @@ source-map-resolve@^0.5.0:
   integrity sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==
   dependencies:
     atob "^2.1.1"
+    decode-uri-component "^0.2.0"
+    resolve-url "^0.2.1"
+    source-map-url "^0.4.0"
+    urix "^0.1.0"
+
+source-map-resolve@^0.5.2:
+  version "0.5.3"
+  resolved "https://registry.yarnpkg.com/source-map-resolve/-/source-map-resolve-0.5.3.tgz#190866bece7553e1f8f267a2ee82c606b5509a1a"
+  integrity sha512-Htz+RnsXWk5+P2slx5Jh3Q66vhQj1Cllm0zvnaY98+NFx+Dv2CF/f5O/t8x+KaNdrdIAsruNzoh/KpialbqAnw==
+  dependencies:
+    atob "^2.1.2"
     decode-uri-component "^0.2.0"
     resolve-url "^0.2.1"
     source-map-url "^0.4.0"


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- Is it a bug fix, feature, docs update, ... -->

**What kind of change does this PR introduce?**
Feature. Closes #296.
<!-- You can also link to an open issue here -->

**What is the current behavior?**
- It's not possible to pass a custom component, we can only use values from SemanticUIReact;
- It's not possible to customize the clear icon, it always renders the `close` icon.
<!-- if this is a feature change -->

**What is the new behavior?**
- It's possible to pass a custom component to the `icon` prop;
- It's possible to pass a value from SemanticUIReact or a custom component to the `clearIcon` prop.
<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation
- [x] Tests
- [ ] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->

<!-- Thank you for contributing! -->
