### PR TITLE
fix(datepicker): fire onChange callback when typed date is invalid

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "@storybook/react": "5.3.19",
     "@testing-library/jest-dom": "5.11.2",
     "@testing-library/react": "10.4.8",
+    "@testing-library/user-event": "12.1.0",
     "@types/jest": "26.0.9",
     "@types/storybook__react": "5.2.1",
     "autoprefixer": "9.8.6",
@@ -80,7 +81,7 @@
     "semantic-ui-react": ">=0.75.0"
   },
   "resolutions": {
-    "handlebars" : "4.5.0"
+    "handlebars": "4.5.0"
   },
   "jest": {
     "globals": {
@@ -88,7 +89,9 @@
         "tsConfig": "tsconfig.test.json"
       }
     },
-    "setupFilesAfterEnv": ["./jest.setup.ts"],
+    "setupFilesAfterEnv": [
+      "./jest.setup.ts"
+    ],
     "transform": {
       ".+\\.css$": "jest-transform-css",
       ".(js|ts)x?": "ts-jest"

--- a/src/__tests__/_utils.tsx
+++ b/src/__tests__/_utils.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { fireEvent, render } from '@testing-library/react';
+import { SemanticDatepickerProps } from '../types';
+import DatePicker from '../';
+
+export const setup = (props: Partial<SemanticDatepickerProps> = {}) => {
+  const options = render(<DatePicker onChange={jest.fn()} {...props} />);
+  const getQuery = props.inline ? options.queryByTestId : options.getByTestId;
+  const getIcon = () => options.getByTestId('datepicker-icon');
+
+  return {
+    ...options,
+    getIcon,
+    openDatePicker: () => fireEvent.click(getIcon()),
+    rerender: (newProps?: Partial<SemanticDatepickerProps>) =>
+      options.rerender(
+        <DatePicker onChange={jest.fn()} {...props} {...newProps} />
+      ),
+    datePickerInput: getQuery('datepicker-input')
+      ?.firstChild as HTMLInputElement,
+  };
+};

--- a/src/__tests__/datepicker.test.tsx
+++ b/src/__tests__/datepicker.test.tsx
@@ -1,28 +1,10 @@
 import React from 'react';
-import { fireEvent, render } from '@testing-library/react';
-import { SemanticDatepickerProps } from '../types';
+import { fireEvent } from '@testing-library/react';
 import localeEn from '../locales/en-US.json';
 import localePt from '../locales/pt-BR.json';
 import { getShortDate } from '../utils';
-import DatePicker from '../';
+import { setup } from './_utils';
 
-const setup = (props: Partial<SemanticDatepickerProps> = {}) => {
-  const options = render(<DatePicker onChange={jest.fn()} {...props} />);
-  const getQuery = props.inline ? options.queryByTestId : options.getByTestId;
-  const getIcon = () => options.getByTestId('datepicker-icon');
-
-  return {
-    ...options,
-    getIcon,
-    openDatePicker: () => fireEvent.click(getIcon()),
-    rerender: (newProps?: Partial<SemanticDatepickerProps>) =>
-      options.rerender(
-        <DatePicker onChange={jest.fn()} {...props} {...newProps} />
-      ),
-    datePickerInput: getQuery('datepicker-input')
-      ?.firstChild as HTMLInputElement,
-  };
-};
 const onBlur = jest.fn();
 let spy: jest.SpyInstance;
 

--- a/src/__tests__/usecases.test.tsx
+++ b/src/__tests__/usecases.test.tsx
@@ -1,0 +1,22 @@
+import { fireEvent, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { setup } from './_utils';
+
+it('onChange is fired when invalid date is typed', () => {
+  const onBlur = jest.fn();
+  const onChange = jest.fn();
+  const { datePickerInput, openDatePicker } = setup({ onBlur, onChange });
+
+  openDatePicker();
+  fireEvent.click(screen.getByText('Today'));
+
+  expect(onChange).toHaveBeenCalledTimes(1);
+  expect(onBlur).toHaveBeenCalledTimes(1);
+
+  userEvent.type(datePickerInput, '{backspace}');
+  fireEvent.keyDown(datePickerInput, { keyCode: 13 });
+
+  expect(datePickerInput.value).toBe('');
+  expect(onBlur).toHaveBeenCalledTimes(2);
+  expect(onChange).toHaveBeenCalledTimes(2);
+});

--- a/src/__tests__/usecases.test.tsx
+++ b/src/__tests__/usecases.test.tsx
@@ -14,6 +14,7 @@ it('onChange is fired when invalid date is typed', () => {
   expect(onBlur).toHaveBeenCalledTimes(1);
 
   userEvent.type(datePickerInput, '{backspace}');
+  userEvent.type(datePickerInput, '{backspace}');
   fireEvent.keyDown(datePickerInput, { keyCode: 13 });
 
   expect(datePickerInput.value).toBe('');

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -342,7 +342,7 @@ class SemanticDatepicker extends React.Component<
   };
 
   handleBlur = (event?: React.SyntheticEvent) => {
-    const { format, onBlur } = this.props;
+    const { format, onBlur, onChange } = this.props;
     const { typedValue } = this.state;
 
     onBlur(event);
@@ -369,7 +369,9 @@ class SemanticDatepicker extends React.Component<
       }
     }
 
-    this.setState({ typedValue: null });
+    this.setState({ typedValue: null }, () => {
+      onChange(event, { ...this.props, value: null });
+    });
   };
 
   handleChange = (event: React.SyntheticEvent, { value }) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1904,6 +1904,13 @@
     "@babel/runtime" "^7.10.3"
     "@testing-library/dom" "^7.17.1"
 
+"@testing-library/user-event@12.1.0":
+  version "12.1.0"
+  resolved "https://registry.yarnpkg.com/@testing-library/user-event/-/user-event-12.1.0.tgz#a2597419466a93e338c91baa7bb22d4da0309d1d"
+  integrity sha512-aH/XuNFpPD6dA+fh754EGqKeAzpH66HpLJYkv9vOAih2yGmTM8JiZ8uisQDGWRPkc6sxE2zCqDwLR4ZskhRCxw==
+  dependencies:
+    "@babel/runtime" "^7.10.2"
+
 "@types/babel__core@^7.1.0":
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.1.3.tgz#e441ea7df63cd080dfcd02ab199e6d16a735fc30"


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- Is it a bug fix, feature, docs update, ... -->

**What kind of change does this PR introduce?**
Bug fix. Closes #334.
<!-- You can also link to an open issue here -->

**What is the current behavior?**
When the user types an invalid date, but input is updated but the `onChange` callback isn't fired.
<!-- if this is a feature change -->

**What is the new behavior?**
The callback is properly fired.
<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation
- [x] Tests
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->

<!-- Thank you for contributing! -->
