### PR TITLE
feat(datepicker): support custom className and pass it to SUI's input

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ More examples [here](https://react-semantic-ui-datepickers.now.sh).
 ### Form.Input Props
 
 - autoComplete
+- className
 - disabled
 - error
 - iconPosition

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -23,6 +23,7 @@ const style: React.CSSProperties = {
 };
 const semanticInputProps = [
   'autoComplete',
+  'className',
   'clearIcon',
   'disabled',
   'error',

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -39,6 +39,7 @@ export type PickedDayzedProps = Pick<
 
 export type PickedFormInputProps = Pick<
   FormInputProps,
+  | 'className'
   | 'disabled'
   | 'error'
   | 'iconPosition'


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- Is it a bug fix, feature, docs update, ... -->

**What kind of change does this PR introduce?**
Feature. Closes #337.
<!-- You can also link to an open issue here -->

**What is the current behavior?**
No support for custom `className`.
<!-- if this is a feature change -->

**What is the new behavior?**
`className` is supported and passed down to Semantic UI's Input, like when using `semantic-ui-react`.
<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation
- [x] Tests
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->

<!-- Thank you for contributing! -->
