### PR TITLE
refactor(datepicker): remove focus from clear button

### DIFF
--- a/src/components/icon.tsx
+++ b/src/components/icon.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { Icon as SUIIcon } from 'semantic-ui-react';
 import { SemanticDatepickerProps } from '../types';
-import { keys } from '../utils';
 
 type CustomIconProps = {
   clearIcon: SemanticDatepickerProps['clearIcon'];
@@ -16,12 +15,6 @@ const CustomIcon = ({
   isClearIconVisible,
   onClear,
 }: CustomIconProps) => {
-  const onKeydown = (evt: KeyboardEvent) => {
-    if (evt.keyCode === keys.enter || evt.keyCode === keys.space) {
-      onClear();
-    }
-  };
-
   if (isClearIconVisible && clearIcon && React.isValidElement(clearIcon)) {
     return React.cloneElement(clearIcon, {
       'data-testid': 'datepicker-clear-icon',
@@ -36,10 +29,7 @@ const CustomIcon = ({
         data-testid="datepicker-clear-icon"
         link
         name={clearIcon}
-        role="button"
-        tabIndex="0"
         onClick={onClear}
-        onKeyDown={onKeydown}
       />
     );
   }


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- Is it a bug fix, feature, docs update, ... -->

**What kind of change does this PR introduce?**
Refactor. Related to [this comment](https://github.com/arthurdenner/react-semantic-ui-datepickers/issues/510#issuecomment-773857951).
<!-- You can also link to an open issue here -->

**What is the current behavior?**
When the input is focused, the content is selected. When the user presses `Tab`, we focus the clear button.
<!-- if this is a feature change -->

**What is the new behavior?**
Focus the clear button is a bit unnecessary since the content is selected every time the input is focused, allowing the user to clear it by pressing `Backspace` or `Delete`.
<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [ ] Tests
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->

<!-- Thank you for contributing! -->
