### PR TITLE
Dutch translation for days and months

### DIFF
--- a/src/components/calendar/calendar.tsx
+++ b/src/components/calendar/calendar.tsx
@@ -125,7 +125,7 @@ const Calendar: React.FC<CalendarProps> = ({
                 </div>
 
                 <span title={`${months[calendar.month]} ${calendar.year}`}>
-                  {months[calendar.month].slice(0, 3)} {calendar.year}
+                  {months[calendar.month].slice(0, 10)} {calendar.year}
                 </span>
 
                 <div style={styles.rightBtn}>

--- a/src/locales/nl-BE.json
+++ b/src/locales/nl-BE.json
@@ -1,0 +1,30 @@
+{
+  "todayButton": "Vandaag",
+  "nextMonth": "Volgende maand",
+  "previousMonth": "Vorige maand",
+  "nextYear": "Volgende jaar",
+  "previousYear": "Vorige jaar",
+  "weekdays": [
+    "zondag",
+    "maandag",
+    "dinsdag",
+    "woensdag",
+    "donderdag",
+    "vrijdag",
+    "zaterdag"
+  ],
+  "months": [
+    "januari",
+    "februari",
+    "maart",
+    "april",
+    "mei",
+    "juni",
+    "juli",
+    "augustus",
+    "september",
+    "oktober",
+    "november",
+    "december"
+  ]
+}


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->
Feature, add dutch/belgian translations

**What kind of change does this PR introduce?**

<!-- You can also link to an open issue here -->

**What is the current behavior?**

<!-- if this is a feature change -->

**What is the new behavior?**

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
I sliced the entire size for month names as only 3 first characters does not give correct abbreviation for month March. In dutch this is 'maart' (non capital) and abbreviation is mrt.
https://onzetaal.nl/taaladvies/afkortingen-dagen-en-maanden/

<!-- Thank you for contributing! -->
