### PR TITLE
test: freeze time when testing keyboard accessibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "rollup-plugin-typescript2": "0.30.0",
     "semantic-ui-css": "2.4.1",
     "semantic-ui-react": "2.0.3",
+    "timekeeper": "2.2.0",
     "tsdx": "0.13.3",
     "tslib": "2.1.0",
     "typescript": "4.2.4"

--- a/src/__tests__/usecases.test.tsx
+++ b/src/__tests__/usecases.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import subDays from 'date-fns/subDays';
+import tk from 'timekeeper';
 import { getShortDate } from '../utils';
 import { setup } from './_utils';
 
@@ -36,6 +37,10 @@ it('onFocus is fired when input is focused', () => {
 });
 
 it('navigation with keyboard is possible', () => {
+  const frozenDate = new Date('2021-01-24');
+
+  tk.freeze(frozenDate);
+
   const now = new Date();
   const today = getShortDate(now)!;
   const yesterday = getShortDate(subDays(now, 1))!;
@@ -43,6 +48,7 @@ it('navigation with keyboard is possible', () => {
   const sevenDaysAgo = getShortDate(subDays(now, 7))!;
   const { getByTestId } = setup({
     autoFocus: true,
+    date: frozenDate,
     keepOpenOnSelect: true,
     showOutsideDays: true,
   });
@@ -63,4 +69,6 @@ it('navigation with keyboard is possible', () => {
 
   fireEvent.keyDown(document.activeElement!, { keyCode: 40 });
   expect(todayCell).toHaveFocus();
+
+  tk.reset();
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -12942,6 +12942,11 @@ through@^2.3.6:
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
   integrity sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=
 
+timekeeper@2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/timekeeper/-/timekeeper-2.2.0.tgz#9645731fce9e3280a18614a57a9d1b72af3ca368"
+  integrity sha512-W3AmPTJWZkRwu+iSNxPIsLZ2ByADsOLbbLxe46UJyWj3mlYLlwucKiq+/dPm0l9wTzqoF3/2PH0AGFCebjq23A==
+
 timers-browserify@^2.0.4:
   version "2.0.11"
   resolved "https://registry.yarnpkg.com/timers-browserify/-/timers-browserify-2.0.11.tgz#800b1f3eee272e5bc53ee465a04d0e804c31211f"


### PR DESCRIPTION


<!-- Is it a bug fix, feature, docs update, ... -->

**What kind of change does this PR introduce?**
Fix a long standing issue.
<!-- You can also link to an open issue here -->

**What is the current behavior?**
When a PR is created at the start or end of a month, the keyboard accessibility test fails because the relative last or next weeks can't be accessed.
<!-- if this is a feature change -->

**What is the new behavior?**
By fixing the time with the `timekeeper` library, we can ensure the time will always be a valid one for performing the tests.
<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [x] Tests
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->

<!-- Thank you for contributing! -->
