### PR TITLE
fix locale import for esm

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -17,6 +17,7 @@ import { BasicDatePicker, RangeDatePicker } from './pickers';
 import { Locale, SemanticDatepickerProps } from './types';
 import Calendar from './components/calendar';
 import Input from './components/input';
+import localeOptions from "./locales";
 
 const style: React.CSSProperties = {
   display: 'inline-block',
@@ -166,17 +167,15 @@ class SemanticDatepicker extends React.Component<
 
   get locale() {
     const { locale } = this.props;
-
-    let localeJson: Locale;
-
-    try {
-      localeJson = require(`./locales/${locale}.json`);
-    } catch (e) {
+    
+    const localeKey = locale.replace("-", "_");
+    
+    if (!localeOptions.hasOwnProperty(localeKey)) {
       console.warn(`"${locale}" is not a valid locale`);
-      localeJson = require('./locales/en-US.json');
+      return localeOptions["en_US"];
     }
-
-    return localeJson;
+    
+    return localeOptions[localeKey];
   }
 
   get weekdays() {

--- a/src/locales/index.js
+++ b/src/locales/index.js
@@ -1,0 +1,45 @@
+import bg_BG from "./bg-BG";
+import ca_ES from "./ca-ES";
+import cs_CZ from "./cs-CZ";
+import de_DE from "./de-DE";
+import en_US from "./en-US";
+import es_ES from "./es-ES";
+import et_EE from "./et-EE";
+import fi_FI from "./fi-FI";
+import fr_FR from "./fi-FI";
+import he_IL from "./he-IL";
+import it_IT from './it-IT';
+import ja_JP from "./ja-JP";
+import ko_KR from "./ko-KR";
+import nb_NO from "./nb-NO";
+import nn_NO from "./nn-NO";
+import pl_PL from "./pl-PL";
+import pt_BR from "./pt-BR";
+import ru_RU from "./ru-RU";
+import sv_SE from "./sv-SE";
+import tr_TR from "./tr-TR";
+import zh_CN from "./zh-CN";
+
+export default {
+    bg_BG,
+    ca_ES,
+    cs_CZ,
+    de_DE,
+    en_US,
+    es_ES,
+    et_EE,
+    fi_FI,
+    fr_FR,
+    he_IL,
+    it_IT,
+    ja_JP,
+    ko_KR,
+    nb_NO,
+    nn_NO,
+    pl_PL,
+    pt_BR,
+    ru_RU,
+    sv_SE,
+    tr_TR,
+    zh_CN,
+};


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- Is it a bug fix, feature, docs update, ... -->

**What kind of change does this PR introduce?**
This PR fixes the locale import issue for esm js file.

<!-- You can also link to an open issue here -->

**What is the current behavior?**
see issue https://github.com/arthurdenner/react-semantic-ui-datepickers/issues/176

<!-- if this is a feature change -->

**What is the new behavior?**
The fix will replace the `require` module with native ES `import`.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [X] Tests
- [X] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->

<!-- Thank you for contributing! -->
