### PR TITLE
fix(datepicker): reset state properly when clearOnSameDateClick is false

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -296,26 +296,11 @@ class SemanticDatepicker extends React.Component<
       format,
       keepOpenOnSelect,
       onChange,
-      clearOnSameDateClick,
       formatOptions,
     } = this.props;
 
     if (!newDate) {
-      // if clearOnSameDateClick is true (this is the default case)
-      // then reset the state. This is what was previously the default
-      // behavior, without a specific prop.
-      if (clearOnSameDateClick) {
-        this.resetState(event);
-      } else {
-        // Don't reset the state. Instead, close or keep open the
-        // datepicker according to the value of keepOpenOnSelect.
-        // Essentially, follow the default behavior of clicking a date
-        // but without changing the value in state.
-        this.setState({
-          isVisible: keepOpenOnSelect,
-        });
-      }
-
+      this.resetState(event);
       return;
     }
 

--- a/src/pickers/basic.tsx
+++ b/src/pickers/basic.tsx
@@ -7,14 +7,18 @@ class DatePicker extends React.Component<BasicDatePickerProps> {
     { selectable, date },
     event: React.SyntheticEvent
   ) => {
-    const { selected: selectedDate, onChange } = this.props;
+    const { clearOnSameDateClick, selected: selectedDate, onChange } = this.props;
 
     if (!selectable) {
       return;
     }
 
     let newDate = date;
-    if (selectedDate && selectedDate.getTime() === date.getTime()) {
+    if (
+      selectedDate &&
+      selectedDate.getTime() === date.getTime() &&
+      clearOnSameDateClick
+    ) {
       newDate = null;
     }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -99,6 +99,7 @@ export type BaseDatePickerProps = DayzedProps & {
 };
 
 export interface BasicDatePickerProps extends BaseDatePickerProps {
+  clearOnSameDateClick?: boolean
   onChange: (event: React.SyntheticEvent, date: Date | null) => void;
   selected: Date;
 }


### PR DESCRIPTION
<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- Is it a bug fix, feature, docs update, ... -->

**What kind of change does this PR introduce?**
Bug fix. Relates to #693.
<!-- You can also link to an open issue here -->

**What is the current behavior?**
When `clearOnSameDateClick={false}`, the state is not reset properly.
<!-- if this is a feature change -->

**What is the new behavior?**
The state is reset properly because `clearOnSameDateClick` is taken into account before setting `newDate` to `null`.
<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->

<!-- Thank you for contributing! -->
