### PR TITLE
Remove outer div (fixes #19)

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ It supports most props of Form.Input and Dayzed components. Check the [supported
   - [Usage](#usage)
   - [Supported Props](#supported-props)
     - [Own Props](#own-props)
+    - [Form.Field Props](#formfield-props)
     - [Form.Input Props](#forminput-props)
     - [Dayzed Props](#dayzed-props)
   - [Customization](#customization)
@@ -96,6 +97,15 @@ More examples [here](https://react-semantic-ui-datepickers.now.sh).
 | showToday            | boolean                                                       | no       | true                | Hides the "Today" button if false                                                                                                                                           |
 | type                 | string                                                        | no       | basic               | Type of input to render. Available options: 'basic' and 'range'                                                                                                             |
 | value                | Date\|Date[]                                                  | no       | --                  | The value of the datepicker                                                                                                                                                 |
+
+### Form.Field Props
+
+- disabled
+- error
+- fieldClassName &rarr; className
+- inline
+- required
+- width
 
 ### Form.Input Props
 

--- a/src/components/input.tsx
+++ b/src/components/input.tsx
@@ -1,5 +1,11 @@
 import React from 'react';
-import { Form, Input, FormInputProps } from 'semantic-ui-react';
+import {
+  Form,
+  Input,
+  FormInputProps,
+  FormFieldProps,
+  Ref,
+} from 'semantic-ui-react';
 import { SemanticDatepickerProps } from '../types';
 import CustomIcon from './icon';
 
@@ -7,10 +13,17 @@ type InputProps = FormInputProps & {
   clearIcon: SemanticDatepickerProps['clearIcon'];
   icon: SemanticDatepickerProps['icon'];
   isClearIconVisible: boolean;
+  fieldProps: FormFieldProps;
+  fieldRef: React.Ref<HTMLElement>;
+  children?: React.ReactNode;
 };
 
 const inputData = {
   'data-testid': 'datepicker-input',
+};
+
+const style: React.CSSProperties = {
+  position: 'relative',
 };
 
 const CustomInput = React.forwardRef<Input, InputProps>((props, ref) => {
@@ -24,30 +37,38 @@ const CustomInput = React.forwardRef<Input, InputProps>((props, ref) => {
     onFocus,
     required,
     value,
+    fieldProps,
+    fieldRef,
+    children,
     ...rest
   } = props;
 
   return (
-    <Form.Field error={error} required={required}>
-      {label && <label htmlFor={rest.id as string | undefined}>{label}</label>}
-      <Input
-        {...rest}
-        ref={ref}
-        error={error}
-        required={required}
-        icon={
-          <CustomIcon
-            clearIcon={clearIcon}
-            icon={icon}
-            isClearIconVisible={isClearIconVisible}
-            onClear={onClear}
-          />
-        }
-        input={inputData}
-        onFocus={onFocus}
-        value={value}
-      />
-    </Form.Field>
+    <Ref innerRef={fieldRef}>
+      <Form.Field {...fieldProps} style={style}>
+        {label && (
+          <label htmlFor={rest.id as string | undefined}>{label}</label>
+        )}
+        <Input
+          {...rest}
+          ref={ref}
+          error={error}
+          required={required}
+          icon={
+            <CustomIcon
+              clearIcon={clearIcon}
+              icon={icon}
+              isClearIconVisible={isClearIconVisible}
+              onClear={onClear}
+            />
+          }
+          input={inputData}
+          onFocus={onFocus}
+          value={value}
+        />
+        {children}
+      </Form.Field>
+    </Ref>
   );
 });
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -18,11 +18,6 @@ import { Locale, SemanticDatepickerProps } from './types';
 import Calendar from './components/calendar';
 import Input from './components/input';
 
-const style: React.CSSProperties = {
-  display: 'inline-block',
-  position: 'relative',
-};
-
 const semanticInputProps = [
   'autoComplete',
   'autoFocus',
@@ -59,6 +54,14 @@ const semanticInputProps = [
   'tabIndex',
   'transparent',
   'readOnly',
+];
+
+const semanticFormFieldProps = [
+  'disabled',
+  'error',
+  'inline',
+  'required',
+  'width',
 ];
 
 type SemanticDatepickerState = {
@@ -150,6 +153,19 @@ class SemanticDatepicker extends React.Component<
     return {
       ...props,
       placeholder,
+    };
+  }
+
+  get fieldProps() {
+    const props = pick(semanticFormFieldProps, this.props);
+    const className =
+      this.props.fieldClassName !== undefined
+        ? this.props.fieldClassName
+        : null;
+
+    return {
+      ...props,
+      className,
     };
   }
 
@@ -428,21 +444,22 @@ class SemanticDatepicker extends React.Component<
     return inline ? (
       datepickerComponent
     ) : (
-      <div className="field" style={style} ref={this.el}>
-        <Input
-          {...this.inputProps}
-          isClearIconVisible={Boolean(clearable && selectedDateFormatted)}
-          onBlur={this.handleBlur}
-          onChange={this.handleChange}
-          onClear={this.clearInput}
-          onFocus={readOnly ? null : this.showCalendar}
-          onKeyDown={this.handleKeyDown}
-          readOnly={readOnly || datePickerOnly}
-          ref={this.inputRef}
-          value={typedValue || selectedDateFormatted}
-        />
+      <Input
+        {...this.inputProps}
+        isClearIconVisible={Boolean(clearable && selectedDateFormatted)}
+        onBlur={this.handleBlur}
+        onChange={this.handleChange}
+        onClear={this.clearInput}
+        onFocus={readOnly ? null : this.showCalendar}
+        onKeyDown={this.handleKeyDown}
+        readOnly={readOnly || datePickerOnly}
+        fieldProps={this.fieldProps}
+        fieldRef={this.el}
+        ref={this.inputRef}
+        value={typedValue || selectedDateFormatted}
+      >
         {isVisible && datepickerComponent}
-      </div>
+      </Input>
     );
   }
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,6 +1,10 @@
 import format from 'date-fns/format';
 import { Props as DayzedProps, RenderProps } from 'dayzed';
-import { FormInputProps, SemanticICONS } from 'semantic-ui-react';
+import {
+  FormInputProps,
+  SemanticICONS,
+  SemanticWIDTHS,
+} from 'semantic-ui-react';
 
 export type Object = { [key: string]: any };
 
@@ -93,6 +97,8 @@ export type SemanticDatepickerProps = PickedDayzedProps &
     type: 'basic' | 'range';
     datePickerOnly: boolean;
     value: DayzedProps['selected'] | null;
+    fieldClassName?: string;
+    width?: SemanticWIDTHS;
   };
 
 export type BaseDatePickerProps = DayzedProps & {


### PR DESCRIPTION
<!--
Make sure you've read the CONTRIBUTING.md file.
Fill out the information to help the review and merge of your pull request!
-->

**What kind of change does this PR introduce?**
<!-- You can also link to an open issue here -->
- Adds properties `width` and `fieldClassName` to the `<SemanticDatepicker>` element, forwarding them in addition to the existing properties `disabled`, `error`, `inline`, `required` to the existing `<Form.Field>` element.
- Wraps the `<Form.Field>` element with a `<Ref>` element, to set the ref `this.el` on the `<Form.Field>` element
- Sets `position: relative` CSS on the existing `<Form.Field>` element
- Removes the outer div

**What is the current behavior?**
You cannot set `className` or `width` on the inner `<Form.Field>` element.

**What is the new behavior?**
You can now set `className` or `width` on the inner `<Form.Field>` element.

There is also one less `<div>` in the DOM, which is nice.

**Checklist**:
<!-- Put an "x" in the box like [x] Documentation -->
- [x] Documentation
- [x] Tests
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- Feel free to add additional comments -->

I'm not quite sure if there are any additional steps needed before merging this, so I am requesting a review before anything is merged.