### PR TITLE
feat(locales): improved locale of zh-CN

### DIFF
--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -1,7 +1,7 @@
 {
   "todayButton": "今天",
   "nextMonth": "下个月",
-  "previousMonth": "前一个月",
+  "previousMonth": "上个月",
   "nextYear": "明年",
   "previousYear": "去年",
   "weekdays": [


### PR DESCRIPTION
**What kind of change does this PR introduce?**

improved locale of zh-CN. Changed "前一个月" to "上个月". As a native speaker, I think “上个月” is more natural than “前一个月” in this context.

**What is the current behavior?**


**What is the new behavior?**


**Checklist**:
<!-- Put an "x" in the box like [x] Documentation -->
- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- Make sure you've read the CONTRIBUTING.md file too -->
<!-- Feel free to add additional comments -->
