### PR TITLE
Fix auto-closing if used in open shadow DOM

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -216,8 +216,8 @@ class SemanticDatepicker extends React.Component<
   mousedownCb = (mousedownEvent) => {
     const { isVisible } = this.state;
 
-    if (isVisible && this.el) {
-      if (this.el.current && !this.el.current.contains(mousedownEvent.target)) {
+    if (isVisible && this.el && this.el.) {
+      if (this.el.current && !this.el.current.contains(mousedownEvent.composedPath()[0])) {
         this.close();
       }
     }


### PR DESCRIPTION
**What kind of change does this PR introduce?**
<!-- You can also link to an open issue here -->
Fixes auto-closing of the calendar popup when the component is used in an open shadow DOM.


**What is the current behavior?**
When the component is used in an open shadow DOM, the popup is closed on any click, no matter whether it's in the popup or not.


**What is the new behavior?**
The popup is closed only if the user has clicked outside of the popup.


**Checklist**:
<!-- Put an "x" in the box like [x] Documentation -->
- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- Make sure you've read the CONTRIBUTING.md file too -->
<!-- Feel free to add additional comments -->
